### PR TITLE
Test enhancement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Tests\\": "tests/"
+            "Tests\\SimpleCli\\": "tests/SimpleCli/"
         }
     },
     "bin": [

--- a/src/SimpleCli/EnhancedCommandBase.php
+++ b/src/SimpleCli/EnhancedCommandBase.php
@@ -9,5 +9,6 @@ use SimpleCli\Options\Verbose;
 
 abstract class EnhancedCommandBase extends CommandBase
 {
-    use Quiet, Verbose;
+    use Quiet;
+    use Verbose;
 }

--- a/src/SimpleCli/SimpleCli.php
+++ b/src/SimpleCli/SimpleCli.php
@@ -32,17 +32,17 @@ use SimpleCli\Traits\Parameters;
  */
 abstract class SimpleCli implements Writer
 {
-    use Input,
-        Output,
-        Name,
-        File,
-        Commands,
-        CommandTrait,
-        Parameters,
-        Arguments,
-        Options,
-        Composer,
-        Documentation;
+    use Input;
+    use Output;
+    use Name;
+    use File;
+    use Commands;
+    use CommandTrait;
+    use Parameters;
+    use Arguments;
+    use Options;
+    use Composer;
+    use Documentation;
 
     public function __construct(array $colors = null, array $backgrounds = null)
     {
@@ -138,7 +138,7 @@ abstract class SimpleCli implements Writer
         }
 
         /**
-         * @var Help $helper
+         * @var Help
          * @psalm-suppress UndefinedDocblockClass
          */
         $helper = $commander;
@@ -286,7 +286,7 @@ abstract class SimpleCli implements Writer
     private function getCommandClassFromName(array $commands, string $command): ?string
     {
         /**
-         * @var string $commandClass
+         * @var string
          */
         $commandClass = $commands[$command];
 
@@ -308,7 +308,7 @@ abstract class SimpleCli implements Writer
     private function createCommander(string $commandClass): ?Command
     {
         /**
-         * @var Command $commander
+         * @var Command
          * @psalm-var Command $commander
          */
         $commander = new $commandClass();

--- a/src/SimpleCli/SimpleCliCommand/Create.php
+++ b/src/SimpleCli/SimpleCliCommand/Create.php
@@ -17,7 +17,9 @@ use SimpleCli\SimpleCli;
  */
 class Create implements Command
 {
-    use Help, Quiet, Verbose;
+    use Help;
+    use Quiet;
+    use Verbose;
 
     /**
      * List of program classes to convert into executable CLI programs.
@@ -120,7 +122,7 @@ class Create implements Command
             }
 
             /**
-             * @var SimpleCli $createdCli
+             * @var SimpleCli
              */
             $createdCli = new $className();
 

--- a/tests/SimpleCli/DemoApp/DemoCommand.php
+++ b/tests/SimpleCli/DemoApp/DemoCommand.php
@@ -12,7 +12,8 @@ use SimpleCli\SimpleCli;
  */
 class DemoCommand implements Command
 {
-    use Verbose, Help;
+    use Verbose;
+    use Help;
 
     /**
      * @option

--- a/tests/SimpleCli/DemoApp/TraitCommand.php
+++ b/tests/SimpleCli/DemoApp/TraitCommand.php
@@ -12,7 +12,8 @@ use SimpleCli\Traits\Input;
  */
 class TraitCommand implements Command
 {
-    use Verbose, Input;
+    use Verbose;
+    use Input;
 
     public function run(SimpleCli $cli): bool
     {

--- a/tests/SimpleCli/SimpleCliCommand/CreateTest.php
+++ b/tests/SimpleCli/SimpleCliCommand/CreateTest.php
@@ -21,7 +21,7 @@ class CreateTest extends TestCase
      */
     protected $currentDirectory;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/SimpleCli/SimpleCliTest.php
+++ b/tests/SimpleCli/SimpleCliTest.php
@@ -283,7 +283,7 @@ class SimpleCliTest extends TestCase
      */
     public function testGetCommandTraits()
     {
-        self::assertSame([
+        static::assertSame([
             'SimpleCli\Options\Verbose' => 'SimpleCli\Options\Verbose',
             'SimpleCli\Traits\Input'    => 'SimpleCli\Traits\Input',
         ], (new InteractiveCli())->traits(TraitCommand::class));

--- a/tests/SimpleCli/Traits/ComposerTest.php
+++ b/tests/SimpleCli/Traits/ComposerTest.php
@@ -36,7 +36,7 @@ class ComposerTest extends TraitsTestCase
     public function testSetVendorDirectory()
     {
         /**
-         * @var string $path
+         * @var string
          */
         $path = realpath(__DIR__);
         $command = new DemoCli();
@@ -91,7 +91,7 @@ class ComposerTest extends TraitsTestCase
         file_put_contents($vendorDirectory.'/composer/installed.json', json_encode($packages));
 
         /**
-         * @var InstalledPackage $installedPackage
+         * @var InstalledPackage
          */
         $installedPackage = $command->getInstalledPackage('foo/bar');
         static::assertInstanceOf(InstalledPackage::class, $installedPackage);


### PR DESCRIPTION
# Changed log
- According to the [official PHPUnit doc](https://phpunit.de/manual/7.0/en/appendixes.assertions.html#appendixes.assertions.static-vs-non-static-usage-of-assertion-methods), it can use the `$this` or `self` to make assertion method calls.
Using the `self` to replace the `static`.
- To be compatible with the PHPUnit fixture methods, adding the native `void` type hint.
- Changing into the `"Tests\\SimpleCli\\": "tests/SimpleCli/"` to make `autoload-dev` clear to know loading test classes.
- Fix coding style via StyleCI tool. The analysis log is available [here](https://github.styleci.io/analyses/L3ZpaK).